### PR TITLE
Add Support for Traditional or USB Serial Port

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 find_package(PkgConfig)
 pkg_check_modules(GTKMM REQUIRED gtkmm-4.0)
 
-add_executable(neonobd neonobd.cpp bluetooth-serial-port.cpp home.cpp mainwindow.cpp settings.cpp waitdialog.cpp logger.cpp connect-button.cpp terminal.cpp)
+add_executable(neonobd neonobd.cpp hardware-interface.cpp bluetooth-serial-port.cpp home.cpp mainwindow.cpp settings.cpp waitdialog.cpp logger.cpp connect-button.cpp terminal.cpp serial-port.cpp)
 
 target_include_directories(neonobd PRIVATE "${PROJECT_SOURCE_DIR}" ${GTKMM_INCLUDE_DIRS})
 

--- a/src/bluetooth-serial-port.cpp
+++ b/src/bluetooth-serial-port.cpp
@@ -23,14 +23,16 @@
 #include <iomanip>
 #include <sys/socket.h>
 #include <sstream>
+#include <glibmm/main.h>
+#include <giomm/resource.h>
+#include <giomm/dbuserror.h>
 
 std::weak_ptr<BluetoothSerialPort> BluetoothSerialPort::bluetoothSerialPort;
 Gio::DBus::InterfaceVTable BluetoothSerialPort::profile_vtable {&BluetoothSerialPort::profile_method};
 Gio::DBus::InterfaceVTable BluetoothSerialPort::agent_vtable {&BluetoothSerialPort::agent_method};
 
 BluetoothSerialPort::BluetoothSerialPort() :
-    probe_in_progress{false},
-    sock_fd{-1}
+    probe_in_progress{false}
 {
     Logger::debug("Created BluetoothSerialPort.");
 }
@@ -116,64 +118,6 @@ bool BluetoothSerialPort::connect(const Glib::ustring& device_name) {
 
     initiate_connection(remoteDevices[device_name]);
     return true;
-}
-
-std::vector<char>::size_type 
-BluetoothSerialPort::read(std::vector<char>& buf,
-                          std::vector<char>::size_type buf_size,
-                          HardwareInterface::Flags flags)
-{
-    std::shared_lock lock(sock_fd_mutex);
-    if (sock_fd >= 0)
-    {
-        buf.resize(buf_size);
-        auto result = recv(sock_fd, buf.data(), buf_size * sizeof(char), 0);
-        if(result != -1)
-            return result;
-    }
-    return 0;
-}
-
-std::vector<char>::size_type BluetoothSerialPort::write(const std::vector<char>& buf)
-{
-    std::shared_lock lock(sock_fd_mutex);
-    if (sock_fd >= 0)
-    {
-        auto result = send(sock_fd, buf.data(), buf.size() * sizeof(char), 0);
-        if(result != -1)
-            return result;
-    }
-    return 0;
-}
-
-std::size_t 
-BluetoothSerialPort::read(std::string& buf,
-                          std::size_t buf_size,
-                          HardwareInterface::Flags flags)
-{
-    std::shared_lock lock(sock_fd_mutex);
-    if (sock_fd >= 0)
-    {
-        buf.resize(buf_size);
-        auto result = recv(sock_fd, buf.data(), buf.size(), 0);
-        if(result != -1) {
-            buf.resize(result);
-            return result;
-        }
-    }
-    return 0;
-}
-
-std::size_t BluetoothSerialPort::write(const std::string& buf)
-{
-    std::shared_lock lock(sock_fd_mutex);
-    if (sock_fd >= 0)
-    {
-        auto result = send(sock_fd, buf.data(), buf.size(), 0);
-        if(result != -1)
-            return result;
-    }
-    return 0;
 }
 
 void BluetoothSerialPort::set_timeout(int milliseconds) {

--- a/src/bluetooth-serial-port.h
+++ b/src/bluetooth-serial-port.h
@@ -20,8 +20,9 @@
 #include "hardware-interface.h"
 #include <cstdint>
 #include <unordered_map>
-#include <shared_mutex>
 #include <memory>
+#include <giomm/dbusproxy.h>
+#include <giomm/dbusobjectmanagerclient.h>
 #include "neonobd_types.h"
 
 using neon::ResponseType;
@@ -38,14 +39,6 @@ class BluetoothSerialPort : public HardwareInterface,
         bool connect(const Glib::ustring& device_name) override;
         void respond_from_user(const Glib::VariantBase&  response,
                                const Glib::RefPtr<void>&  signal_handle) override;
-        std::vector<char>::size_type read(std::vector<char>&  buf, 
-                                          std::vector<char>::size_type buf_size = 1024,
-                                          HardwareInterface::Flags flags = HardwareInterface::FLAGS_NONE) override;
-        std::vector<char>::size_type write(const std::vector<char>&  buf) override;
-        std::size_t read(std::string&  buf,
-                         std::size_t buf_size = 1024,
-                         HardwareInterface::Flags flags = HardwareInterface::FLAGS_NONE) override;
-        std::size_t write(const std::string&  buf) override;
 
         void set_timeout(int milliseconds) override;
 
@@ -128,8 +121,6 @@ class BluetoothSerialPort : public HardwareInterface,
         sigc::connection preConnectionScanResult;
         bool probe_in_progress;
         int probe_progress;
-        int sock_fd;
-        std::shared_mutex sock_fd_mutex;
         Glib::DBusObjectPathString connected_device_path;
         sigc::signal<void()> agent_cancel;
         Glib::RefPtr<Gio::DBus::MethodInvocation> request_pin_invocation;

--- a/src/combobox.h
+++ b/src/combobox.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <tuple>
+#include <optional>
 #include <gtkmm/combobox.h>
 #include <glibmm/refptr.h>
 #include <gtkmm/liststore.h>

--- a/src/hardware-interface.cpp
+++ b/src/hardware-interface.cpp
@@ -1,0 +1,85 @@
+/* This file is part of neonobd - OBD diagnostic software.
+ * Copyright (C) 2022  Brian LePage
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "hardware-interface.h"
+#include <unistd.h>
+
+sigc::connection
+HardwareInterface::attach_connect_complete(const sigc::slot<void(bool)>& slot) {
+    return complete_connection.connect(slot);
+}
+sigc::connection
+HardwareInterface::attach_user_prompt(const sigc::slot<void(const Glib::ustring&,
+                                      ResponseType,
+                                      Glib::RefPtr<void>)>& slot) {
+    return request_user_input.connect(slot);
+}
+
+std::vector<char>::size_type
+HardwareInterface::read(std::vector<char>& buf,
+                        std::vector<char>::size_type buf_size)
+{
+    std::shared_lock lock(sock_fd_mutex);
+    if (sock_fd >= 0)
+    {
+        buf.resize(buf_size);
+        auto result = ::read(sock_fd, buf.data(), buf_size * sizeof(char));
+        if(result != -1)
+            return result;
+    }
+    return 0;
+}
+
+std::vector<char>::size_type HardwareInterface::write(const std::vector<char>& buf)
+{
+    std::shared_lock lock(sock_fd_mutex);
+    if (sock_fd >= 0)
+    {
+        auto result = ::write(sock_fd, buf.data(), buf.size() * sizeof(char));
+        if(result != -1)
+            return result;
+    }
+    return 0;
+}
+
+std::size_t
+HardwareInterface::read(std::string& buf, std::size_t buf_size) {
+    std::shared_lock lock(sock_fd_mutex);
+    if (sock_fd >= 0)
+    {
+        buf.resize(buf_size);
+        auto result = ::read(sock_fd, buf.data(), buf.size());
+        if(result != -1) {
+            buf.resize(result);
+            return result;
+        }
+    }
+    return 0;
+}
+
+std::size_t HardwareInterface::write(const std::string& buf)
+{
+    std::shared_lock lock(sock_fd_mutex);
+    if (sock_fd >= 0)
+    {
+        auto result = ::write(sock_fd, buf.data(), buf.size());
+        if(result != -1)
+            return result;
+    }
+    return 0;
+}
+

--- a/src/hardware-interface.h
+++ b/src/hardware-interface.h
@@ -19,37 +19,36 @@
 #pragma once
 #include <vector>
 #include <string>
-#include <giomm.h>
+#include <shared_mutex>
+#include <glibmm/ustring.h>
+#include <sigc++/connection.h>
+#include <sigc++/signal.h>
+#include <glibmm/variant.h>
 #include "neonobd_types.h"
 
 using neon::ResponseType;
 
 class HardwareInterface {
     public:
-        enum Flags { FLAGS_NONE = 0 };
         virtual bool connect(const Glib::ustring& device_name) = 0;
-        sigc::connection attach_connect_complete(const sigc::slot<void(bool)>& slot) { 
-            return complete_connection.connect(slot);
-        }
+        sigc::connection attach_connect_complete(const sigc::slot<void(bool)>& slot);
         sigc::connection attach_user_prompt(const sigc::slot<void(const Glib::ustring&, 
                                                 ResponseType, 
-                                                Glib::RefPtr<void>)>& slot) { 
-            return request_user_input.connect(slot);
-        }
+                                                Glib::RefPtr<void>)>& slot);
         virtual void respond_from_user(const Glib::VariantBase& response,
                                        const Glib::RefPtr<void>& signal_handle) = 0;
         virtual std::vector<char>::size_type read(std::vector<char>& buf,
-                                                  std::vector<char>::size_type buf_size = 1024,
-                                                  Flags flags = FLAGS_NONE) = 0; 
-        virtual std::vector<char>::size_type write(const std::vector<char>& buf) = 0;
+                                                  std::vector<char>::size_type buf_size = 1024);
+        virtual std::vector<char>::size_type write(const std::vector<char>& buf);
         virtual std::size_t read(std::string& buf,
-                                 std::size_t buf_size = 1024,
-                                 Flags flags = FLAGS_NONE) = 0; 
-        virtual std::size_t write(const std::string& buf) = 0;
+                                 std::size_t buf_size = 1024);
+        virtual std::size_t write(const std::string& buf);
         virtual void set_timeout(int milliseconds) {}
 
     protected:
         sigc::signal<void(bool)> complete_connection;
         sigc::signal<void(const Glib::ustring&, ResponseType, Glib::RefPtr<void>)> request_user_input;
+        int sock_fd = -1;
+        std::shared_mutex sock_fd_mutex;
 
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -20,7 +20,8 @@
 #include <iostream>
 
 MainWindow::MainWindow() :
-    bluetoothSerialPort{BluetoothSerialPort::getBluetoothSerialPort()}
+    bluetoothSerialPort{BluetoothSerialPort::getBluetoothSerialPort()},
+    serialPort{new SerialPort}
 {
     css = Gtk::CssProvider::create();
     css->load_from_resource("/stylesheets/appstyle.css");
@@ -59,8 +60,7 @@ void MainWindow::setHardwareInterface(InterfaceType ifType) {
         hardwareInterface = bluetoothSerialPort;
         break;
       case neon::SERIAL_IF:
-        hardwareInterface.reset();
-        //hardwareInterface = serialPort; ????
+        hardwareInterface = serialPort;
         break;
     }    
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -27,6 +27,7 @@
 #include "bluetooth-serial-port.h"
 #include "hardware-interface.h"
 #include "neonobd_types.h"
+#include "serial-port.h"
 
 using neon::ResponseType;
 using neon::InterfaceType;
@@ -39,6 +40,7 @@ class MainWindow : public Gtk::Window
         MainWindow& operator=(const MainWindow&) = delete;
         virtual ~MainWindow();
         std::shared_ptr<BluetoothSerialPort> bluetoothSerialPort;
+        std::shared_ptr<SerialPort> serialPort;
         std::shared_ptr<HardwareInterface> hardwareInterface;
         std::unique_ptr<Home> home;
         std::unique_ptr<Settings> settings;

--- a/src/resources/neonobd_ui.xml
+++ b/src/resources/neonobd_ui.xml
@@ -277,7 +277,46 @@ along with neonobd.  If not, see <http://www.gnu.org/licenses/>.
                                         </child>
                                         <child>
                                             <object class="GtkGrid" id="serial_port_settings">
-                                                <property name="name">serial_port_settings</property>
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="visible">True</property>
+                                                        <property name="halign">start</property>
+                                                        <property name="label" translatable="yes">Serial Port Device: </property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="serial_device">
+                                                        <property name="visible">True</property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">0</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="visible">True</property>
+                                                        <property name="halign">start</property>
+                                                        <property name="label" translatable="yes">Serial Port BAUD Rate: </property>
+                                                        <layout>
+                                                            <property name="column">0</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkComboBoxText" id="serial_baudrate">
+                                                        <property name="visible">True</property>
+                                                        <layout>
+                                                            <property name="column">1</property>
+                                                            <property name="row">1</property>
+                                                        </layout>
+                                                    </object>
+                                                </child>
                                             </object>
                                         </child>
                                     </object>

--- a/src/serial-port.cpp
+++ b/src/serial-port.cpp
@@ -1,0 +1,187 @@
+/* This file is part of neonobd - OBD diagnostic software.
+ * Copyright (C) 2022  Brian LePage
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "serial-port.h"
+#include "logger.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <system_error>
+#include <fstream>
+#include <sstream>
+#include <filesystem>
+#include <unordered_map>
+
+const std::unordered_map<std::string, speed_t> SerialPort::baudrates =
+    {{"9600", B9600}, {"19200", B19200}, {"38400", B38400}, {"57600", B57600},
+     {"115200", B115200}, {"230400", B230400}};
+
+SerialPort::SerialPort() {
+    dispatcher.connect(sigc::mem_fun(*this, &SerialPort::connect_complete));
+}
+
+SerialPort::~SerialPort() {
+    if(connect_thread && connect_thread->joinable()) {
+        connect_thread->join();
+    }
+    Logger::debug("Destroying Serial Port");
+}
+
+std::vector<Glib::ustring> SerialPort::get_valid_baudrates() {
+    std::vector<Glib::ustring> output;
+    for(auto& [baudrate_str, baudrate] : baudrates) {
+        output.push_back(baudrate_str);
+    }
+    return output;
+}
+
+std::vector<Glib::ustring> SerialPort::get_serial_devices() {
+    std::ifstream procfile("/proc/tty/drivers");
+    if(!procfile)
+        return {};
+
+    std::unordered_map<std::filesystem::path, std::vector<std::string>> file_prefixes;
+    while(!procfile.eof()) {
+        char line[128];
+        procfile.getline(line, sizeof(line));
+        std::stringstream line_ss(line);
+        std::vector<std::string> words;
+        while(!line_ss.eof()) {
+            std::string word;
+            line_ss >> word;
+            if(line_ss) {
+                words.push_back(word);
+            }
+        }
+
+        if(words.size() <= 2 ||
+           words[words.size()-1] != "serial")
+        {
+            continue;
+        }
+
+       std::filesystem::path path(words[1]);
+
+       file_prefixes[path.parent_path()].push_back(path.filename().string());
+    }
+
+    std::vector<Glib::ustring> device_list;
+    for(auto& [folder, prefixes] : file_prefixes) {
+        for(auto& dir_entry : std::filesystem::directory_iterator(folder)) {
+            for(auto& prefix : prefixes) {
+                if(dir_entry.path().filename().string().starts_with(prefix)) {
+                    device_list.push_back(dir_entry.path().string());
+                    break;
+                }
+            }
+        }
+    }
+
+    return device_list;
+}
+
+void SerialPort::set_baudrate(const Glib::ustring& baudrate) {
+    this->baudrate = baudrates.at(baudrate);
+}
+
+void SerialPort::connect_complete() {
+    connect_thread->join();
+    connect_thread.reset();
+    complete_connection.emit(connected);
+}
+
+void SerialPort::initiate_connection(const Glib::ustring& device_name) {
+    try {
+        std::lock_guard lock(sock_fd_mutex);
+        sock_fd = open(device_name.c_str(), O_RDWR);
+
+        if(sock_fd == -1) {
+            throw std::system_error(errno, std::generic_category(),
+                "Failed to open serial port.");
+        }
+
+        //Device opened.  Set BAUD rate and other port settings.
+
+        termios port_settings;
+
+        if(tcgetattr(sock_fd, &port_settings) == -1 ||
+           cfsetispeed(&port_settings, baudrate) == -1 ||
+           cfsetospeed(&port_settings, baudrate) == -1)
+        {
+            throw std::system_error(errno, std::generic_category(),
+                    "Failed to set baudrate");
+        }
+
+        cfmakeraw(&port_settings);
+        port_settings.c_cc[VMIN] = 0;
+        port_settings.c_cc[VTIME] = timeout;
+
+        if(tcsetattr(sock_fd, TCSANOW, &port_settings) == -1) {
+            throw std::system_error(errno, std::generic_category(),
+                    "Failed to apply serial port settings");
+        }
+
+        connected = true;
+
+    } catch(const std::system_error& e) {
+        Logger::error(e.what());
+        if(sock_fd != -1) {
+            close(sock_fd);
+            sock_fd = -1;
+        }
+    }
+
+    dispatcher.emit();
+}
+
+bool SerialPort::connect(const Glib::ustring& device_name) {
+    if(sock_fd != -1) {
+        Logger::error("Connection to serial port already exists.");
+        return false;
+    }
+
+    if(connect_thread) {
+        Logger::error("Connection attempt already in progress.");
+        return false;
+    }
+
+    connect_thread = std::make_unique<std::thread>([this, device_name](){
+            this->initiate_connection(device_name);});
+
+    return true;
+}
+
+void SerialPort::set_timeout(int milliseconds) {
+    timeout = milliseconds / 100;
+
+    std::shared_lock lock(sock_fd_mutex);
+    if(sock_fd == -1)
+        return;
+
+    termios port_settings;
+    if(tcgetattr(sock_fd, &port_settings) == -1) {
+        Logger::error("Failed to retrieve serial port settings.");
+        return;
+    }
+
+    port_settings.c_cc[VMIN] = 0;
+    port_settings.c_cc[VTIME] = timeout;
+
+    if(tcsetattr(sock_fd, TCSANOW, &port_settings) == -1) {
+        Logger::error("Failed to set serial port timeout.");
+    }
+}

--- a/src/serial-port.h
+++ b/src/serial-port.h
@@ -1,0 +1,50 @@
+/* This file is part of neonobd - OBD diagnostic software.
+ * Copyright (C) 2022  Brian LePage
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "hardware-interface.h"
+#include <termios.h>
+#include <glibmm/dispatcher.h>
+#include <memory>
+#include <thread>
+
+class SerialPort: public HardwareInterface,
+                  public sigc::trackable
+{
+    public:
+        SerialPort();
+        ~SerialPort();
+        bool connect(const Glib::ustring& device_name) override;
+        void respond_from_user(const Glib::VariantBase& response,
+                               const Glib::RefPtr<void>& signal_handle) override {}
+        void set_timeout(int milliseconds) override;
+
+        void set_baudrate(const Glib::ustring& baudrate);
+        static std::vector<Glib::ustring> get_valid_baudrates();
+        static std::vector<Glib::ustring> get_serial_devices();
+    private:
+        speed_t baudrate = B38400;
+        static const std::unordered_map<std::string, speed_t> baudrates;
+        Glib::Dispatcher dispatcher;
+        std::unique_ptr<std::thread> connect_thread;
+        bool connected = false;
+        int timeout = 0;
+
+        void initiate_connection(const Glib::ustring& device_name);
+        void connect_complete();
+};
+

--- a/src/settings.h
+++ b/src/settings.h
@@ -28,7 +28,9 @@
 #include <gtkmm/messagedialog.h>
 #include <gtkmm/grid.h>
 #include <gtkmm/stack.h>
+#include <giomm/settings.h>
 #include "bluetooth-serial-port.h"
+#include "serial-port.h"
 #include "combobox.h"
 #include "neonobd_types.h"
 
@@ -50,6 +52,7 @@ class Settings : public sigc::trackable {
         MainWindow* window;
         Glib::PropertyProxy<Glib::ustring> visibleView;
         std::shared_ptr<BluetoothSerialPort> btHardwareInterface;
+        std::shared_ptr<SerialPort> serialHardwareInterface;
         Gtk::Button* homeButton;
         Gtk::CheckButton* bluetooth_rb;
         Gtk::CheckButton* serial_rb;
@@ -62,6 +65,8 @@ class Settings : public sigc::trackable {
         Gtk::ProgressBar* btScanProgress;
         Gtk::Grid* btGrid;
         Gtk::Grid* serialGrid;
+        Gtk::ComboBoxText* serialDeviceCombo;
+        Gtk::ComboBoxText* serialBaudrateCombo;
         sigc::connection btScanConnection;
         Glib::RefPtr<Gio::Settings> settings;
         InterfaceType iftype;
@@ -71,7 +76,12 @@ class Settings : public sigc::trackable {
         void selectBluetooth();
         void selectBluetoothController();
         void selectBluetoothDevice();
+        void selectSerialDevice();
+        void selectSerialBaudrate();
         void scanBluetooth();
         void scanComplete();
         void updateScanProgress(int percentComplete);
+        static void populateComboBox(const std::vector<Glib::ustring>& values,
+                                     Gtk::ComboBoxText* combobox,
+                                     const Glib::ustring& default_value);
 };

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -55,7 +55,7 @@ void Terminal::read_data() {
     hwif->set_timeout(100);
     std::string tempBuffer;
     while(!stop_reader) {
-        auto bytecount = hwif->read(tempBuffer, 128, HardwareInterface::FLAGS_NONE);
+        auto bytecount = hwif->read(tempBuffer);
         if(bytecount) {
             std::lock_guard lock(read_buffer_mutex);
             read_buffer.append(tempBuffer);


### PR DESCRIPTION
Add new HardwareInterface class SerialPort to
support connections through tty serial devices
(e.g., ttyS0, ttyUSB0).

Make serial port settings configurable from the
settings menu.

Allow connection to be made to either a Bluetooth
or tty serial port based on user configuration.