### PR TITLE
Add Packaging to Build System

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 cmake_minimum_required(VERSION 3.20)
 
-project(neonobd VERSION 0.1)
+project(neonobd VERSION 0.1.1)
 
 option(RUN_CPPCHECK "Run cppcheck during compilation" OFF)
 option(RUN_CLANG_TIDY "Run clang-tidy during compilation" OFF)
@@ -55,5 +55,9 @@ target_link_libraries(neonobd PRIVATE ${GTKMM_LIBRARIES} resources)
 
 install(TARGETS neonobd RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-
 add_subdirectory(resources)
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/packaging")
+    add_subdirectory(packaging)
+endif()
+

--- a/src/packaging/CMakeLists.txt
+++ b/src/packaging/CMakeLists.txt
@@ -1,0 +1,78 @@
+# This file is part of neonobd - OBD diagnostic software.
+# Copyright (C) 2024  Brian LePage
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+if(UNIX)
+    if(NOT APPLE AND NOT CYGWIN)
+        option(PACKAGE_RPM "Create RPM Package" OFF)
+        option(PACKAGE_DEB "Create DEB Package" OFF)
+        option(PACKAGE_ARCH "Create ARCH Package" OFF)
+    endif()
+endif()
+
+set(CPACK_PACKAGE_DESCRIPTION "neonobd OBD diagnostic software")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "neonobd")
+set(CPACK_SOURCE_IGNORE_FILES "/.gitignore;/packaging")
+set(CPACK_PACKAGE_CONTACT "Brian LePage")
+set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
+list(APPEND CPACK_CUSTOM_INSTALL_VARIABLES SKIP_SCHEMA_COMPILATION=1)
+
+if(PACKAGE_RPM)
+    list(APPEND CPACK_GENERATOR RPM)
+    list(APPEND CPACK_SOURCE_GENERATOR RPM)
+    set(CPACK_RPM_PACKAGE_LICENSE "GPL 3.0")
+    set(CPACK_RPM_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION}")
+    set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_CURRENT_SOURCE_DIR}/post_install.sh")
+    set(CPACK_RPM_FILE_NAME RPM-DEFAULT)
+endif()
+
+if(PACKAGE_DEB)
+    list(APPEND CPACK_GENERATOR DEB)
+    list(APPEND CPACK_SOURCE_GENERATOR DEB)
+    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+    set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS ON)
+endif()
+
+if(PACKAGE_ARCH)
+    #Arch Binary Package:
+    list(APPEND CPACK_GENERATOR External)
+    list(APPEND CPACK_SOURCE_GENERATOR External)
+    set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/create_arch_pkg.cmake")
+endif()
+
+set(SAVED_CPACK_GENERATOR "${CPACK_GENERATOR}")
+set(SAVED_CPACK_SOURCE_GENERATOR "${CPACK_SOURCE_GENERATOR}")
+
+include(CPack)
+
+# If no package generators are selected, CPACK will automatically select
+# a set of generators to use.  The following will override that behavior
+# if the user selected no packages by removing the generators in the CPACK
+# config files.
+
+macro(remove_generators CONFIG_FILE)
+    file(READ "${CONFIG_FILE}" FILE_DATA)
+    string(REGEX REPLACE "CPACK_GENERATOR \"[^\"]*\"" "CPACK_GENERATOR \"\"" FILE_DATA "${FILE_DATA}")
+    file(WRITE "${CONFIG_FILE}" "${FILE_DATA}")
+endmacro()
+
+if(NOT SAVED_CPACK_GENERATOR)
+    remove_generators("${CPACK_OUTPUT_CONFIG_FILE}")
+endif()
+
+if(NOT SAVED_CPACK_SOURCE_GENERATOR)
+    remove_generators("${CPACK_SOURCE_OUTPUT_CONFIG_FILE}")
+endif()
+

--- a/src/packaging/PKGBUILD.in
+++ b/src/packaging/PKGBUILD.in
@@ -1,0 +1,51 @@
+# This file is part of neonobd - OBD diagnostic software.
+# Copyright (C) 2024  Brian LePage
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Maintainer: Brian LePage <bjlepage22@gmail.com>
+pkgname=@CPACK_PACKAGE_NAME@
+pkgver=@CPACK_PACKAGE_VERSION_MAJOR@.@CPACK_PACKAGE_VERSION_MINOR@
+pkgrel=@CPACK_PACKAGE_VERSION_PATCH@
+epoch=
+pkgdesc="@CPACK_PACKAGE_DESCRIPTION@"
+arch=('x86_64')
+url="@CPACK_PACKAGE_HOMEPAGE_URL@"
+license=('GPL 3.0')
+groups=()
+depends=('gtkmm-4.0')
+makedepends=(cmake)
+checkdepends=()
+optdepends=('bluez: for bluetooth support')
+provides=()
+conflicts=()
+replaces=()
+backup=()
+options=()
+install=
+changelog=
+source=(@ARCH_PACKAGE_SOURCES@)
+noextract=()
+validpgpkeys=()
+
+build() {
+    [[ ${#source[@]} -eq 0 ]] && return
+    cmake -B build src
+    cmake --build build
+}
+
+package() {
+    cd @ARCH_BUILD_DIR@
+    cmake -DSKIP_SCHEMA_COMPILATION=1 -DCMAKE_INSTALL_PREFIX=$pkgdir@CPACK_PACKAGING_INSTALL_PREFIX@ -P cmake_install.cmake
+}

--- a/src/packaging/cpack_install.cmake
+++ b/src/packaging/cpack_install.cmake
@@ -1,5 +1,5 @@
 # This file is part of neonobd - OBD diagnostic software.
-# Copyright (C) 2022-2024  Brian LePage
+# Copyright (C) 2024  Brian LePage
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,17 +14,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-add_library(resources OBJECT resources.c)
-
-add_custom_command(
-    OUTPUT resources.c 
-    COMMAND glib-compile-resources --target ${CMAKE_CURRENT_BINARY_DIR}/resources.c --generate-source app.gresource.xml
-    DEPENDS app.gresource.xml appstyle.css neonobd_ui.xml bluez-agent1.xml bluez-profile1.xml
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-target_include_directories(resources PRIVATE ${GTKMM_INCLUDE_DIRS})
-
-install(FILES com.github.beardedone55.neonobd.gschema.xml DESTINATION share/glib-2.0/schemas)
-
-install(SCRIPT compile_schema.cmake)
-
+message("CPACK Installation.  Skip schema compilation.")
+set(SKIP_SCHEMA_COMPILATION 1)

--- a/src/packaging/create_arch_pkg.cmake
+++ b/src/packaging/create_arch_pkg.cmake
@@ -1,0 +1,73 @@
+# This file is part of neonobd - OBD diagnostic software.
+# Copyright (C) 2024  Brian LePage
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+find_program(MAKEPKG makepkg REQUIRED)
+list(GET CPACK_BUILD_SOURCE_DIRS 0 SOURCE_DIRECTORY)
+string(CONCAT ARCH_PACKAGE_NAME 
+       "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION_MAJOR}"
+       ".${CPACK_PACKAGE_VERSION_MINOR}-${CPACK_PACKAGE_VERSION_PATCH}")
+
+set(ARCH_PKG "${CPACK_PACKAGE_DIRECTORY}/packaging")
+
+if(CPACK_TOPLEVEL_TAG STREQUAL "Linux")
+    message("Creating Arch Package......")
+
+    set(ARCH_BUILD_DIR "${CPACK_PACKAGE_DIRECTORY}")
+    configure_file("${SOURCE_DIRECTORY}/packaging/PKGBUILD.in" "${ARCH_PKG}/PKGBUILD" @ONLY)
+
+    execute_process(COMMAND ${MAKEPKG} -f 
+                    WORKING_DIRECTORY "${ARCH_PKG}")
+
+    string(CONCAT ARCH_PACKAGE_NAME "${ARCH_PACKAGE_NAME}"
+           "-x86_64.pkg.tar.zst")
+
+    list(APPEND CPACK_EXTERNAL_BUILT_PACKAGES 
+         ${ARCH_PKG}/${ARCH_PACKAGE_NAME})
+
+elseif(CPACK_TOPLEVEL_TAG STREQUAL "Linux-Source")
+    message("Creating Arch Source Package......")
+    set(ARCH_PACKAGE_SOURCES ${CPACK_SOURCE_PACKAGE_FILE_NAME}.tar.gz)
+    set(ARCH_BUILD_DIR "./build")
+    configure_file("${SOURCE_DIRECTORY}/packaging/PKGBUILD.in" "${ARCH_PKG}/PKGBUILD" @ONLY)
+    find_program(TAR tar REQUIRED)
+    set(TAR_COMMAND ${TAR})
+    foreach(EXCLUDE_PATTERN ${CPACK_SOURCE_IGNORE_FILES})
+        list(APPEND TAR_COMMAND --exclude=*${EXCLUDE_PATTERN})
+    endforeach()
+    list(APPEND TAR_COMMAND -czf 
+        "${ARCH_PKG}/${ARCH_PACKAGE_SOURCES}"
+        src)
+    message("${TAR_COMMAND}")
+    execute_process(COMMAND ${TAR_COMMAND} 
+                    WORKING_DIRECTORY "${SOURCE_DIRECTORY}/..")
+
+    execute_process(COMMAND ${MAKEPKG} -g
+                    OUTPUT_VARIABLE SOURCE_CHECKSUM
+                    WORKING_DIRECTORY "${ARCH_PKG}")
+
+    file(APPEND "${ARCH_PKG}/PKGBUILD" "${SOURCE_CHECKSUM}")
+
+    execute_process(COMMAND ${MAKEPKG} -f -S 
+                    WORKING_DIRECTORY "${ARCH_PKG}")
+
+    string(CONCAT ARCH_PACKAGE_NAME "${ARCH_PACKAGE_NAME}"
+           ".src.tar.gz")
+
+    list(APPEND CPACK_EXTERNAL_BUILT_PACKAGES 
+         "${ARCH_PKG}/${ARCH_PACKAGE_NAME}")
+
+endif()
+

--- a/src/packaging/post_install.sh
+++ b/src/packaging/post_install.sh
@@ -1,0 +1,1 @@
+glib-compile-schemas %{_prefix}/share/glib-2.0/schemas

--- a/src/resources/compile_schema.cmake
+++ b/src/resources/compile_schema.cmake
@@ -1,5 +1,5 @@
 # This file is part of neonobd - OBD diagnostic software.
-# Copyright (C) 2022-2024  Brian LePage
+# Copyright (C) 2024  Brian LePage
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,17 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-add_library(resources OBJECT resources.c)
-
-add_custom_command(
-    OUTPUT resources.c 
-    COMMAND glib-compile-resources --target ${CMAKE_CURRENT_BINARY_DIR}/resources.c --generate-source app.gresource.xml
-    DEPENDS app.gresource.xml appstyle.css neonobd_ui.xml bluez-agent1.xml bluez-profile1.xml
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-target_include_directories(resources PRIVATE ${GTKMM_INCLUDE_DIRS})
-
-install(FILES com.github.beardedone55.neonobd.gschema.xml DESTINATION share/glib-2.0/schemas)
-
-install(SCRIPT compile_schema.cmake)
+if(NOT DEFINED SKIP_SCHEMA_COMPILATION)
+    find_program(GLIB_COMPILE_SCHEMAS glib-compile-schemas)
+    execute_process(COMMAND ${GLIB_COMPILE_SCHEMAS} ${CMAKE_INSTALL_PREFIX}/share/glib-2.0/schemas)
+else()
+    message("Skipping schema compilation.")
+endif()
 


### PR DESCRIPTION
Utilize CPACK to build DEB, RPM, or Arch
packages (binary and source).

Added cmake options to enable build of
DEB, RPM, and/or Arch packages.